### PR TITLE
Fix iframe panel url

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ panel_iframe:
   sqlite-web:
     title: SQLite Web
     icon: mdi:database
-    url: http://addres.to.your.hass.io:4444
+    url: https://address.to.your.hass.io:6210
 ```
 
 ## Changelog & Releases


### PR DESCRIPTION
# Proposed Changes

Fixes a typo (addres -> address), uses httpS (ssl is true by default) and most important: this add-on uses port 6210 instead of 4444.

## Related Issues

NA