### PR TITLE
Updates lua-resty-http to version 0.13-r0

### DIFF
--- a/sqlite-web/Dockerfile
+++ b/sqlite-web/Dockerfile
@@ -16,7 +16,7 @@ RUN \
     make=4.2.1-r2 \
   \
   && apk add --no-cache \
-    lua-resty-http=0.12-r1 \
+    lua-resty-http=0.13-r0 \
     nginx-mod-http-lua=1.14.2-r0 \
     nginx=1.14.2-r0 \
     cython=0.29.2-r0 \


### PR DESCRIPTION

# Proposed Changes

This PR will update `lua-resty-http` to version `0.13-r0`.

This PR was created automatically, please check the "Files changed" tab
before merging!

***

This PR was created with [repoupdater][repoupdater] :tada:

[repoupdater]: https://pypi.org/project/repoupdater/
