### PR TITLE
🔨Fix path and dependencies

### DIFF
--- a/sqlite-web/Dockerfile
+++ b/sqlite-web/Dockerfile
@@ -25,6 +25,7 @@ RUN \
     cython=0.29.19-r0 \
     patch=2.7.6-r6 \
     python3=3.8.5-r0 \
+    py3-setuptools=47.0.0-r0 \
   \
   && pip3 install \
     --no-cache-dir \

--- a/sqlite-web/Dockerfile
+++ b/sqlite-web/Dockerfile
@@ -23,6 +23,7 @@ RUN \
     lua-resty-http=0.15-r0 \
     nginx=1.18.0-r0 \
     cython=0.29.19-r0 \
+    patch=2.7.6-r6 \
     python3=3.8.5-r0 \
   \
   && pip3 install \

--- a/sqlite-web/rootfs/etc/cont-init.d/sqlite-web.sh
+++ b/sqlite-web/rootfs/etc/cont-init.d/sqlite-web.sh
@@ -12,13 +12,13 @@ fi
 # Adds favicon
 mv \
     /www/favicon.png \
-    /usr/local/lib/python3.8/site-packages/sqlite_web/static/img/
+    /usr/lib/python3.8/site-packages/sqlite_web/static/img/
 
 patch \
-    /usr/local/lib/python3.8/site-packages/sqlite_web/templates/base.html \
+    /usr/lib/python3.8/site-packages/sqlite_web/templates/base.html \
     /patches/favicon
 
 # Adds buymeacoffe link
 patch \
-    /usr/local/lib/python3.8/site-packages/sqlite_web/templates/base_tables.html \
+    /usr/lib/python3.8/site-packages/sqlite_web/templates/base_tables.html \
     /patches/buymeacoffee


### PR DESCRIPTION
# Proposed Changes

The addon currently fails to run, which I am guessing is likely to do with changing the base image.

The paths for the Python packages is now /usr/lib/ rather than /usr/local/lib/
The application depends on py3-setuptools and the setup scripts on patch

## Related Issues

None