### PR TITLE
🔨Add optional configurable folder path for DB

### DIFF
--- a/sqlite-web/DOCS.md
+++ b/sqlite-web/DOCS.md
@@ -55,7 +55,13 @@ you are troubleshooting.
 
 ### Option: `database_path`
 
-The path for the database file relative to `/config/`
+The path for the database file relative to `/config/` or the folder path
+configuration.
+
+### Option: `folder_path`
+
+If the database has been moved from `/config/` allows the folder to be specified
+for example `/share/somefolder/`. Please ensure the trailing slash is set.
 
 ### Option: `read_only`
 

--- a/sqlite-web/config.json
+++ b/sqlite-web/config.json
@@ -22,7 +22,7 @@
     "80/tcp": "SQLite Web interface (Not required for Ingress)",
     "6220/tcp": "Datasette API endpoint"
   },
-  "map": ["ssl", "config:rw"],
+  "map": ["share:rw", "ssl", "config:rw"],
   "options": {
     "database_path": "home-assistant_v2.db",
     "read_only": true,

--- a/sqlite-web/config.json
+++ b/sqlite-web/config.json
@@ -34,6 +34,7 @@
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
     "database_path": "str",
+    "folder_path": "str?",
     "read_only": "bool",
     "datasette": "bool",
     "ssl": "bool",

--- a/sqlite-web/rootfs/etc/cont-init.d/sqlite-web.sh
+++ b/sqlite-web/rootfs/etc/cont-init.d/sqlite-web.sh
@@ -3,9 +3,12 @@
 # Home Assistant Community Add-on: SQLite Web
 # This files adds some patches to the add-on
 # ==============================================================================
-
+folder_path=/config/
+if bashio::config.has_value 'folder_path'; then
+    folder_path=$(bashio::config 'folder_path')
+fi
 # Check if database file exist
-if ! bashio::fs.file_exists "/config/$(bashio::config 'database_path')"; then
+if ! bashio::fs.file_exists "$folder_path$(bashio::config 'database_path')"; then
     bashio::exit.nok 'The configured database file is not found'
 fi
 

--- a/sqlite-web/rootfs/etc/services.d/sqlite-web/run
+++ b/sqlite-web/rootfs/etc/services.d/sqlite-web/run
@@ -4,10 +4,13 @@
 # Runs SQLite Web
 # ==============================================================================
 declare -a options
-
+folder_path=/config/
+if bashio::config.has_value 'folder_path'; then
+    folder_path=$(bashio::config 'folder_path')
+fi
 options+=(-H 0.0.0.0)
 options+=(--no-browser)
-options+=(-x "/config/$(bashio::config 'database_path')")
+options+=(-x "$folder_path$(bashio::config 'database_path')")
 
 if bashio::config.true 'read_only'; then
   options+=(-r)


### PR DESCRIPTION
# Proposed Changes

Adds an option to configure the folder path to the database, as users can move the database to the share folder, primarily to avoid issues with Snapshots.

Made it optional so if not set /Config/ will continue to be used, to avoid breaking changes.


## Related Issues

Fixes #81 