### PR TITLE
Remove obsolete webui from configuration

### DIFF
--- a/sqlite-web/config.json
+++ b/sqlite-web/config.json
@@ -4,7 +4,6 @@
   "slug": "sqlite-web",
   "description": "Explore your SQLite database",
   "url": "https://github.com/hassio-addons/addon-sqlite-web/tree/main/README.md",
-  "webui": "[PROTO:ssl]://[HOST]:[PORT:6210]",
   "ingress": true,
   "ingress_port": 1337,
   "panel_icon": "mdi:database",


### PR DESCRIPTION
# Proposed Changes

Since this add-on uses Ingress, setting a `webui` URL has no effect.
