### PR TITLE
Fix larger table widths on larger screens

### DIFF
--- a/sqlite-web/rootfs/etc/cont-init.d/sqlite-web.sh
+++ b/sqlite-web/rootfs/etc/cont-init.d/sqlite-web.sh
@@ -8,3 +8,7 @@
 patch \
     /usr/lib/python3.8/site-packages/sqlite_web/templates/base_tables.html \
     /patches/buymeacoffee
+
+# Made tables go wide!
+sed -i "s#container#container-fluid#g" \
+    /usr/lib/python3.8/site-packages/sqlite_web/templates/base.html


### PR DESCRIPTION
# Proposed Changes

Makes the base template go wide!

This solves problems on large screens, displaying large tables.
Bootstrap will now just use the width available.

## Related Issues

fixes #88


![image](https://user-images.githubusercontent.com/195327/106600296-7fc4d480-655a-11eb-8707-969a3c6bc70f.png)
