### PR TITLE
Add optional configuration for database location

### DIFF
--- a/sqlite-web/DOCS.md
+++ b/sqlite-web/DOCS.md
@@ -26,7 +26,13 @@ button My button below.
 
 ## Configuration
 
-This add-on has no configuration options.
+**Note**: _Remember to restart the add-on when the configuration is changed._
+
+### Option: Database
+
+An optional database path that can set to instruct SQLite web to use a specific
+database file. When not set, the default Home Assistant database file location
+is used.
 
 ## Changelog & Releases
 

--- a/sqlite-web/config.yaml
+++ b/sqlite-web/config.yaml
@@ -16,3 +16,5 @@ arch:
   - i386
 map:
   - config:rw
+schema:
+  database: "str?"

--- a/sqlite-web/rootfs/etc/cont-init.d/sqlite-web.sh
+++ b/sqlite-web/rootfs/etc/cont-init.d/sqlite-web.sh
@@ -3,6 +3,16 @@
 # Home Assistant Community Add-on: SQLite Web
 # This files adds some patches to the add-on
 # ==============================================================================
+declare database
+
+database="/config/home-assistant_v2.db"
+if bashio::config.has_value 'database'; then
+    database="$(bashio::config 'database')"
+fi
+
+if ! bashio::fs.file_exists "${database}"; then
+    bashio::exit.nok "The database file '${database}' is not found"
+fi
 
 # Adds buymeacoffe link
 patch \

--- a/sqlite-web/rootfs/etc/services.d/sqlite-web/run
+++ b/sqlite-web/rootfs/etc/services.d/sqlite-web/run
@@ -4,10 +4,16 @@
 # Runs SQLite Web
 # ==============================================================================
 declare -a options
+declare database
+
+database="/config/home-assistant_v2.db"
+if bashio::config.has_value 'database'; then
+    database="$(bashio::config 'database')"
+fi
 
 options+=(--host 127.0.0.1)
 options+=(--no-browser)
-options+=(-x "/config/home-assistant_v2.db")
+options+=(-x "${database}")
 
 bashio::log.info 'Starting SQLite Web...'
 

--- a/sqlite-web/translations/en.yaml
+++ b/sqlite-web/translations/en.yaml
@@ -1,0 +1,6 @@
+configuration:
+  database:
+    name: Database
+    description: >-
+      Path to a custom database location to use. This can be helpful in case
+      your database isn't in the default location.

--- a/sqlite-web/translations/en.yaml
+++ b/sqlite-web/translations/en.yaml
@@ -1,3 +1,4 @@
+---
 configuration:
   database:
     name: Database


### PR DESCRIPTION
# Proposed Changes

Adds back an optional configuration option for configuring the database used (as it's requested often). Made it optional, as, by default, it just picks up the HA default database path.

## Related Issues

closes #199
closes #195
closes #143
