### PR TITLE
🚑 Fix nginx paths under ingress for import/export

### DIFF
--- a/sqlite-web/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/sqlite-web/rootfs/etc/nginx/templates/ingress.gtpl
@@ -13,5 +13,15 @@ server {
         sub_filter_once off;
         sub_filter 'href="/' 'href="{{ .entry }}/';
         sub_filter '/static/' '{{ .entry }}/static/';
+        sub_filter '/event_data/' '{{ .entry }}/event_data/';
+        sub_filter '/events/' '{{ .entry }}/events/';
+        sub_filter '/recorder_runs/' '{{ .entry }}/recorder_runs/';
+        sub_filter '/schema_changes/' '{{ .entry }}/schema_changes/';
+        sub_filter '/state_attributes/' '{{ .entry }}/state_attributes/';
+        sub_filter '/states/' '{{ .entry }}/states/';
+        sub_filter '/statistics/' '{{ .entry }}/statistics/';
+        sub_filter '/statistics_meta/' '{{ .entry }}/statistics_meta/';
+        sub_filter '/statistics_runs/' '{{ .entry }}/statistics_runs/';
+        sub_filter '/statistics_short_term/' '{{ .entry }}/statistics_short_term/';
     }
 }


### PR DESCRIPTION
# Proposed Changes

Adds hardcoded table names to the nginx subfilter, so that import/export functions.  I'll be honest and say it's not a great fix, however not sure what else could be done (I believe I captured all table names).

## Related Issues

Fixes #259 
