### PR TITLE
Migrate add-on to new Home Assistant configuration mapping

### DIFF
--- a/sqlite-web/config.yaml
+++ b/sqlite-web/config.yaml
@@ -14,7 +14,7 @@ arch:
   - amd64
   - armv7
 map:
-  - config:rw
+  - homeassistant_config:rw
   - share:rw
 schema:
   database: "str?"

--- a/sqlite-web/rootfs/etc/s6-overlay/s6-rc.d/init-sqlite-web/run
+++ b/sqlite-web/rootfs/etc/s6-overlay/s6-rc.d/init-sqlite-web/run
@@ -6,7 +6,7 @@
 # ==============================================================================
 declare database
 
-database="/config/home-assistant_v2.db"
+database="/homeassistant/home-assistant_v2.db"
 if bashio::config.has_value 'database'; then
     database="$(bashio::config 'database')"
 fi

--- a/sqlite-web/rootfs/etc/s6-overlay/s6-rc.d/sqlite-web/run
+++ b/sqlite-web/rootfs/etc/s6-overlay/s6-rc.d/sqlite-web/run
@@ -7,7 +7,7 @@
 declare -a options
 declare database
 
-database="/config/home-assistant_v2.db"
+database="/homeassistant/home-assistant_v2.db"
 if bashio::config.has_value 'database'; then
     database="$(bashio::config 'database')"
 fi


### PR DESCRIPTION
# Proposed Changes

The add-on now uses `/homeassistant` instead of `/config` to access the Home Assistant configuration (as the latter is deprecated).
