### PR TITLE
Update sqlite-web to v0.6.2

### DIFF
--- a/sqlite-web/requirements.txt
+++ b/sqlite-web/requirements.txt
@@ -1,1 +1,1 @@
-sqlite-web==0.6.1
+sqlite-web==0.6.2


### PR DESCRIPTION
# Proposed Changes

Upgrade sqlite-web to v0.6.2 to fix the problem with new lines in SQL queries.

Thanks to @coleifier for making the upstream change to fix this for HA.

## Related Issues

> This fixes #281

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
