### PR TITLE
Fix Ingress URL Prefix

### DIFF
--- a/sqlite-web/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/sqlite-web/rootfs/etc/nginx/templates/ingress.gtpl
@@ -8,20 +8,6 @@ server {
         allow   172.30.32.2;
         deny    all;
 
-        proxy_pass http://sqlite;
-
-        sub_filter_once off;
-        sub_filter 'href="/' 'href="{{ .entry }}/';
-        sub_filter '/static/' '{{ .entry }}/static/';
-        sub_filter '/event_data/' '{{ .entry }}/event_data/';
-        sub_filter '/events/' '{{ .entry }}/events/';
-        sub_filter '/recorder_runs/' '{{ .entry }}/recorder_runs/';
-        sub_filter '/schema_changes/' '{{ .entry }}/schema_changes/';
-        sub_filter '/state_attributes/' '{{ .entry }}/state_attributes/';
-        sub_filter '/states/' '{{ .entry }}/states/';
-        sub_filter '/statistics/' '{{ .entry }}/statistics/';
-        sub_filter '/statistics_meta/' '{{ .entry }}/statistics_meta/';
-        sub_filter '/statistics_runs/' '{{ .entry }}/statistics_runs/';
-        sub_filter '/statistics_short_term/' '{{ .entry }}/statistics_short_term/';
+        proxy_pass http://sqlite/{{ .entry }}/;
     }
 }

--- a/sqlite-web/rootfs/etc/s6-overlay/s6-rc.d/sqlite-web/run
+++ b/sqlite-web/rootfs/etc/s6-overlay/s6-rc.d/sqlite-web/run
@@ -15,7 +15,7 @@ fi
 options+=(--host 127.0.0.1)
 options+=(--no-browser)
 options+=(-x "${database}")
-options+=(--url-prefix $(bashio::addon.ingress_entry))
+options+=(--url-prefix "$(bashio::addon.ingress_entry)")
 
 bashio::log.info 'Starting SQLite Web...'
 

--- a/sqlite-web/rootfs/etc/s6-overlay/s6-rc.d/sqlite-web/run
+++ b/sqlite-web/rootfs/etc/s6-overlay/s6-rc.d/sqlite-web/run
@@ -15,6 +15,7 @@ fi
 options+=(--host 127.0.0.1)
 options+=(--no-browser)
 options+=(-x "${database}")
+options+=(--url-prefix $(bashio::addon.ingress_entry))
 
 bashio::log.info 'Starting SQLite Web...'
 


### PR DESCRIPTION
# Proposed Changes

Remove specific nginx rewriting and instead run `sqlite-web` with the ingress URL prefix

This means any new URLs added to SQLite Web will automatically work, instead of needing to be added to the ingress config.

## Related Issues

This should resolve the last of the issues with #281 

fixes #281