### PR TITLE
Update config.yaml to Support Addons Config

### DIFF
--- a/sqlite-web/config.yaml
+++ b/sqlite-web/config.yaml
@@ -15,6 +15,7 @@ arch:
   - armv7
 map:
   - homeassistant_config:rw
+  - all_addon_configs:rw
   - share:rw
 schema:
   database: "str?"


### PR DESCRIPTION
# Proposed Changes

Update `config.yaml` map to include all add-on configs so that databases which are stored there can be opened.

## Related

* https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for managing all add-on configurations with read and write permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->